### PR TITLE
Tests : autoload.psr-4 : invalid value (Controlled\tests), namespaces must end with a namespace separator, should be Controlled\tests\

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "autoload": {
         "psr-4": {
             "Controlled\\": "src/",
-            "Controlled\\tests": "tests/"
+            "Controlled\\tests\\": "tests/"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
autoload.psr-4 : invalid value (Controlled\tests), namespaces must end with a namespace separator, should be Controlled\tests\